### PR TITLE
trim whitespace from server IP addresses to prevent SSH connection failure.

### DIFF
--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -46,7 +46,7 @@ const Schema = z.object({
 	description: z.string().optional(),
 	ipAddress: z.string().min(1, {
 		message: "IP Address is required",
-	}),
+	}).transform(val => val.trim()),
 	port: z.number().optional(),
 	username: z.string().optional(),
 	sshKeyId: z.string().min(1, {

--- a/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/handle-servers.tsx
@@ -44,9 +44,9 @@ const Schema = z.object({
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
-	}).transform(val => val.trim()),
+	}),
 	port: z.number().optional(),
 	username: z.string().optional(),
 	sshKeyId: z.string().min(1, {

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -34,9 +34,9 @@ const Schema = z.object({
 		message: "Name is required",
 	}),
 	description: z.string().optional(),
-	ipAddress: z.string().min(1, {
+	ipAddress: z.string().trim().min(1, {
 		message: "IP Address is required",
-	}).transform(val => val.trim()),
+	}),
 	port: z.number().optional(),
 	username: z.string().optional(),
 	sshKeyId: z.string().min(1, {

--- a/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
+++ b/apps/dokploy/components/dashboard/settings/servers/welcome-stripe/create-server.tsx
@@ -36,7 +36,7 @@ const Schema = z.object({
 	description: z.string().optional(),
 	ipAddress: z.string().min(1, {
 		message: "IP Address is required",
-	}),
+	}).transform(val => val.trim()),
 	port: z.number().optional(),
 	username: z.string().optional(),
 	sshKeyId: z.string().min(1, {

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
@@ -33,7 +33,7 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const schema = z.object({
-	serverIp: z.string(),
+	serverIp: z.string().transform(val => val.trim()),
 });
 
 type Schema = z.infer<typeof schema>;

--- a/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
+++ b/apps/dokploy/components/dashboard/settings/web-server/update-server-ip.tsx
@@ -33,7 +33,9 @@ import { toast } from "sonner";
 import { z } from "zod";
 
 const schema = z.object({
-	serverIp: z.string().transform(val => val.trim()),
+	serverIp: z.string().trim().min(1, {
+		message: "Server IP is required",
+	}),
 });
 
 type Schema = z.infer<typeof schema>;

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -121,6 +121,7 @@ const createSchema = createInsertSchema(server, {
 	serverId: z.string().min(1),
 	name: z.string().min(1),
 	description: z.string().optional(),
+	ipAddress: z.string().transform(val => val.trim()),
 });
 
 export const apiCreateServer = createSchema

--- a/packages/server/src/db/schema/server.ts
+++ b/packages/server/src/db/schema/server.ts
@@ -121,7 +121,9 @@ const createSchema = createInsertSchema(server, {
 	serverId: z.string().min(1),
 	name: z.string().min(1),
 	description: z.string().optional(),
-	ipAddress: z.string().transform(val => val.trim()),
+	ipAddress: z.string().trim().min(1, {
+		message: "IP address is required",
+	}),
 });
 
 export const apiCreateServer = createSchema


### PR DESCRIPTION
<img width="1670" height="1080" alt="image" src="https://github.com/user-attachments/assets/fa2b9a0a-321c-4260-8784-38237b6f3c22" />

## 🐛 Fix: Trim whitespace from server IP addresses to prevent SSH connection failures

### Problem
When users input server IP addresses with leading or trailing whitespace, SSH connections fail because the whitespace is not trimmed before attempting the connection.

**Example:**
- User enters: `" 192.168.1.1 "` (with spaces)
- SSH connection fails: `connect ENOTFOUND  192.168.1.1:22`
- User must re-enter IP without whitespace

### Solution
Add `.trim()` transform to IP address validation in all server forms to automatically remove leading/trailing whitespace.

### Changes Made

#### Frontend Forms
- **`handle-servers.tsx`**: Main server creation/editing form
- **`create-server.tsx`**: Onboarding server creation form  
- **`update-server-ip.tsx`**: Web server IP update form

#### Backend Validation
- **`server.ts`**: Server schema validation with trimming

### Implementation Details
```typescript
// Before
ipAddress: z.string().min(1, { message: "IP Address is required" })

// After  
ipAddress: z.string().min(1, { message: "IP Address is required" }).transform(val => val.trim())
```

### Before/After Screenshots

#### Before Fix
<img width="3456" height="1984" alt="image" src="https://github.com/user-attachments/assets/6aa87117-fa67-432d-8c78-ab92adf305df" />
*Server list displays IP address with spaces: `"           127.0.0.1           "`*

#### After Fix  
<img width="3456" height="1984" alt="image" src="https://github.com/user-attachments/assets/9154ffee-2362-4e6e-9dd6-d4725914209d" />
*Server list displays clean IP address: "127.0.0.1"`*

### Testing
- ✅ Created servers with spaces in IP addresses
- ✅ Verified server list displays clean IP addresses
- ✅ Confirmed SSH connections use trimmed IPs
- ✅ Tested multiple IP formats and edge cases

### Impact
- **Better UX**: Users can input IP addresses with spaces without errors
- **Reliable SSH**: Connections succeed with clean IP addresses
- **Data Integrity**: Database stores consistent, clean IP addresses
- **Defense-in-Depth**: Protection at both frontend and backend levels

### Before/After Behavior
**Before:** `" 192.168.1.1 "` → SSH connection fails
**After:** `" 192.168.1.1 "` → `"192.168.1.1"` → SSH connection succeeds

Fixes: Server IP addresses with whitespace causing SSH connection failures



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trim leading/trailing spaces in IP address fields across server creation and update forms.
  * Require a non-empty IP after trimming to prevent accidental empty submissions.
  * Backend now normalizes IP addresses on create to ensure consistently stored, clean values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->